### PR TITLE
udpsend v0.5 - Added input validation 

### DIFF
--- a/udpsend.cpp
+++ b/udpsend.cpp
@@ -33,7 +33,7 @@ const size_t MAX_UDP_MESSAGE_SIZE = 65507; // Maximum size for UDP payload
 
 void printUsage(const char* progName) {
     std::cerr << std::endl << " udpsend v0.4 Copyright (C) 2024 Enrico Heine" << std::endl << std::endl;
-    std::cerr << " https://github.com/Flashdown/udpsend" << std::endl; << std::endl;
+    std::cerr << " https://github.com/Flashdown/udpsend" << std::endl << std::endl;
 
     std::cerr << " This program comes with ABSOLUTELY NO WARRANTY;" << std::endl;
     std::cerr << " This is free software, and you are welcome to redistribute it" << std::endl;

--- a/udpsend.cpp
+++ b/udpsend.cpp
@@ -12,10 +12,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <iostream>
 #include <string>
 #include <cstring>
 #include <cstdlib>
+#include <iostream>
+#include <regex>
+#include <stdexcept>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -27,16 +29,49 @@
 #include <netdb.h>
 #endif
 
-void printUsage(const char* progName) {
-    std::cerr << "Usage: " << progName << " <server> <port> <message>" << std::endl;
-    std::cerr << "  server: IPv4, IPv6 address or FQDN" << std::endl;
-    std::cerr << "  port:   Port number to send the message to" << std::endl;
-    std::cerr << "  message: Message to send via UDP" << std::endl;
+const size_t MAX_UDP_MESSAGE_SIZE = 65507; // Maximum size for UDP payload
 
+void printUsage(const char* progName) {
     std::cerr << std::endl << " udpsend v0.4 Copyright (C) 2024 Enrico Heine" << std::endl << std::endl;
+    std::cerr << " https://github.com/Flashdown/udpsend" << std::endl; << std::endl;
+
     std::cerr << " This program comes with ABSOLUTELY NO WARRANTY;" << std::endl;
     std::cerr << " This is free software, and you are welcome to redistribute it" << std::endl;
     std::cerr << " under the conditions of the GNU General Public License Version 3" << std::endl;
+
+    std::cerr << "Usage: " << progName << " <server> <port> <message>" << std::endl;
+    std::cerr << "  server: IPv4, IPv6 address or FQDN" << std::endl;
+    std::cerr << "  port:   Port number to send the message to (1-65535)" << std::endl;
+    std::cerr << "  message: Message to send via UDP (max 65507 bytes)" << std::endl;
+}
+
+bool isValidPort(const std::string& portStr) {
+    std::regex portRegex("^[0-9]+$");
+    if (std::regex_match(portStr, portRegex)) {
+        int port = std::stoi(portStr);
+        return port >= 1 && port <= 65535; // Valid port range
+    }
+    return false;
+}
+
+bool isValidServer(const std::string& server) {
+    std::regex ipv4SimpleRegex("^[0-9.]+$");
+    std::regex ipv6Regex("^[0-9a-fA-F:]+$");
+    std::regex domainRegex("^([a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$");
+
+    // Allow a server name or IP address up to 200 characters
+    return (server.length() <= 200 &&
+            (std::regex_match(server, ipv4SimpleRegex) ||
+             std::regex_match(server, ipv6Regex) ||
+             std::regex_match(server, domainRegex)));
+}
+
+bool isValidMessage(const std::string& message) {
+    // Regex allows A-Z, a-z, 0-9, whitespace, special characters, and German umlauts
+    std::regex messageRegex("^[A-Za-z0-9\\s!@#$%^&*()_+\\-=\\[\\]{};:'\",.<>?/|`~äöüÄÖÜß]*$");
+
+    // Check message length and content
+    return message.length() <= MAX_UDP_MESSAGE_SIZE && std::regex_match(message, messageRegex);
 }
 
 int main(int argc, char* argv[]) {
@@ -44,24 +79,48 @@ int main(int argc, char* argv[]) {
     int port;
     std::string message;
 
-    if (argc == 4) {
-        server = argv[1];
-        port = std::stoi(argv[2]);
-        message = argv[3];
-    } else if (argc == 3) {
+    try {
+        if (argc == 4) {
+            server = argv[1];
+            if (!isValidServer(server)) {
+                throw std::invalid_argument("Invalid server address or domain name.");
+            }
 
-        server = argv[1];
-        port = std::stoi(argv[2]);
+            if (!isValidPort(argv[2])) {
+                throw std::invalid_argument("Invalid port number. Must be between 1 and 65535.");
+            }
+            port = std::stoi(argv[2]);
 
-        std::cout << "Enter the message to send: ";
-        std::getline(std::cin, message);
+            message = argv[3];
+            if (!isValidMessage(message)) {
+                throw std::invalid_argument("Message is too long for a single UDP packet.");
+            }
+        } else if (argc == 3) {
+            server = argv[1];
+            if (!isValidServer(server)) {
+                throw std::invalid_argument("Invalid server address or domain name.");
+            }
 
-        if (message.empty()) {
-            std::cerr << "Error: Message cannot be empty." << std::endl;
+            if (!isValidPort(argv[2])) {
+                throw std::invalid_argument("Invalid port number. Must be between 1 and 65535.");
+            }
+            port = std::stoi(argv[2]);
+
+            std::cout << "Enter the message to send: ";
+            std::getline(std::cin, message);
+
+            if (message.empty()) {
+                throw std::invalid_argument("Message cannot be empty.");
+            }
+            if (!isValidMessage(message)) {
+                throw std::invalid_argument("Message is too long for a single UDP packet.");
+            }
+        } else {
+            printUsage(argv[0]);
             return EXIT_FAILURE;
         }
-    } else {
-        printUsage(argv[0]);
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
         return EXIT_FAILURE;
     }
 

--- a/udpsend.cpp
+++ b/udpsend.cpp
@@ -1,4 +1,4 @@
-// udpsend v0.4 Copyright (C) 2024 Enrico Heine https://github.com/Flashdown/udpsend
+// udpsend v0.5 Copyright (C) 2024 Enrico Heine https://github.com/Flashdown/udpsend
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License Version 3 as
@@ -32,7 +32,7 @@
 const size_t MAX_UDP_MESSAGE_SIZE = 65507; // Maximum size for UDP payload
 
 void printUsage(const char* progName) {
-    std::cerr << std::endl << " udpsend v0.4 Copyright (C) 2024 Enrico Heine" << std::endl << std::endl;
+    std::cerr << std::endl << " udpsend v0.5 Copyright (C) 2024 Enrico Heine" << std::endl << std::endl;
     std::cerr << " https://github.com/Flashdown/udpsend" << std::endl << std::endl;
 
     std::cerr << " This program comes with ABSOLUTELY NO WARRANTY;" << std::endl;


### PR DESCRIPTION
Port Validation: only digits within the valid range (1–65535).
Server Validation: regular expressions to validate IPv4, IPv6 and domain names, max length 200
Message Validation: ensure message length does not exceed the maximum UDP payload size and regex content check, valid characters (A-z, 0-9, special characters, whitespace, and German umlauts),  
Error Handling: Added std::invalid_argument exceptions for invalid inputs. 
Sensible Limits: Applies appropriate restrictions to avoid excessively large or invalid inputs.